### PR TITLE
Add sync between seek bar and chapter control buttons

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -158,6 +158,10 @@ public class AudioPlayerFragment extends Fragment implements
         return root;
     }
 
+    public void notifyChapterChanged(int chapterIndex) {
+        currentChapterIndex = chapterIndex;
+    }
+
     private void setChapterDividers(Playable media) {
 
         if (media == null) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -158,10 +158,6 @@ public class AudioPlayerFragment extends Fragment implements
         return root;
     }
 
-    public void notifyChapterChanged(int chapterIndex) {
-        currentChapterIndex = chapterIndex;
-    }
-
     private void setChapterDividers(Playable media) {
 
         if (media == null) {
@@ -442,6 +438,7 @@ public class AudioPlayerFragment extends Fragment implements
         int currentPosition = converter.convert(event.getPosition());
         int duration = converter.convert(event.getDuration());
         int remainingTime = converter.convert(Math.max(event.getDuration() - event.getPosition(), 0));
+        currentChapterIndex = ChapterUtils.getCurrentChapterIndex(controller.getMedia(), currentPosition);
         Log.d(TAG, "currentPosition " + Converter.getDurationStringLong(currentPosition));
         if (currentPosition == PlaybackService.INVALID_TIME || duration == PlaybackService.INVALID_TIME) {
             Log.w(TAG, "Could not react to position observer update because of invalid time");

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -156,6 +156,7 @@ public class CoverFragment extends Fragment {
                 displayedChapterIndex = chapterIndex;
                 butNextChapter.setVisibility(View.VISIBLE);
             }
+            ((AudioPlayerFragment) requireParentFragment()).notifyChapterChanged(displayedChapterIndex);
         } else {
             chapterControl.setVisibility(View.GONE);
             detailsWidth = ViewGroup.LayoutParams.WRAP_CONTENT;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -156,7 +156,6 @@ public class CoverFragment extends Fragment {
                 displayedChapterIndex = chapterIndex;
                 butNextChapter.setVisibility(View.VISIBLE);
             }
-            ((AudioPlayerFragment) requireParentFragment()).notifyChapterChanged(displayedChapterIndex);
         } else {
             chapterControl.setVisibility(View.GONE);
             detailsWidth = ViewGroup.LayoutParams.WRAP_CONTENT;


### PR DESCRIPTION
For AntennaPod#5075
This is a one way sync from the buttons to the seek bar. Maybe we want to do this the other way around too? (But in my experience, the asynchronicity is not such a problem there)